### PR TITLE
Fix incorrect domain in manual installation-instructions causing TLS validation-failure.

### DIFF
--- a/install.html
+++ b/install.html
@@ -86,7 +86,7 @@
 				<dl id="fade">
 					<dt><h4>Manual installation</h4></dt>
 					<dd>Clone our repository</dd>
-					<dd><pre>git clone https://github.io/lxc-webpanel/LXC-Web-Panel.git</pre></dd>
+					<dd><pre>git clone https://github.com/lxc-webpanel/LXC-Web-Panel.git</pre></dd>
 					<dd>Install Flask</dd>
 
 					<dd><pre>pip install flask==0.9</pre></dd>


### PR DESCRIPTION
Without the fix, the result of the provided commands are as follows:

```
$ git clone https://github.io/lxc-webpanel/LXC-Web-Panel.git      
Cloning into 'LXC-Web-Panel'...
fatal: unable to access 'https://github.io/lxc-webpanel/LXC-Web-Panel.git/': gnutls_handshake() failed: A TLS packet with unexpected length was received.
$
```
